### PR TITLE
Add CI and CD workflows

### DIFF
--- a/.github/workflows/continuous-delivery.yaml
+++ b/.github/workflows/continuous-delivery.yaml
@@ -71,7 +71,7 @@ jobs:
             # type=semver,pattern={{major}}.{{minor}}
             ## Tags for a push branch event
             # Tags to reflect the last commit of the active branch
-            type=edge,enable=true,branch=main
+            type=edge,enable=true
             ## Other types (currently the followings may be out of scope in this project)
             ## Tags for a push branch event
             # minimal (short sha)

--- a/.github/workflows/continuous-delivery.yaml
+++ b/.github/workflows/continuous-delivery.yaml
@@ -1,0 +1,132 @@
+# This workflow performs continuous delivery (CD).
+# This workflow will build a container image and publish it to container registries.
+name: Continuous Delivery (CD)
+
+# When it's time to do a release,
+# do a full cross-platform build for all supported architectures and
+# push all of them to Docker Hub and GitHub Container Registry (GHCR).
+
+on:
+  # "Build and publish" on merged
+  # Actually, there's no "merged" event.
+  # A "push" event is occurred after the pull request "close" event with "merged" true condition.
+  # The "push" event could replace "merged" event.
+  push:
+    branches:
+      - main
+    tags:
+      # Only trigger on semver shaped tags.
+      - "v*.*.*"
+    paths-ignore:
+      - ".github/**"
+      - "docs/**"
+      - "scripts/**"
+      - "**.md"
+      - ".gitignore"
+      - "LICENSE"
+      - "CODEOWNERS"
+      # - '.all-contributorsrc'
+      # - 'assets/**'
+      # - 'src/testclient/scripts/**'
+  # workflow trigger button
+  # workflow_dispatch:
+
+env:
+  DOCKER_REGISTRY_NAME: cloudbaristaorg
+  GHCR_REGISTRY_NAME: ${{ github.repository_owner }}
+  IMAGE_NAME: ${{ github.event.repository.name }}
+
+jobs:
+  # The job key is "publish-container-image"
+  publish-container-image:
+    # Job name is "Publish a container image"
+    name: Publish a container image
+
+    if: github.repository_owner == 'cloud-barista'
+
+    # This job runs on Ubuntu-latest (Ubuntu 22.04 LTS checked on 2023-12-13)
+    # See https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners
+    runs-on: ubuntu-22.04
+
+    steps:
+      - name: Checkout source code
+        uses: actions/checkout@v4
+
+      # About billing for GitHub Packages
+      # https://docs.github.com/en/billing/managing-billing-for-github-packages/about-billing-for-github-packages
+      - name: Extract metadata from Git reference and GitHub events
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: |
+            # image name for Docker Hub
+            ${{env.DOCKER_REGISTRY_NAME}}/${{env.IMAGE_NAME}}
+            # image name for GitHub Container Registry (GHCR)
+            ghcr.io/${{env.GHCR_REGISTRY_NAME}}/${{env.IMAGE_NAME}}
+          tags: |
+            # See `tags` input: https://github.com/docker/metadata-action?tab=readme-ov-file#tags-input
+            ## Tags for a push tag event
+            # minimal (e.g., 1.2.3)
+            type=semver,enable=true,pattern={{version}}
+            # type=semver,pattern={{major}}.{{minor}}
+            ## Tags for a push branch event
+            # Tags to reflect the last commit of the active branch
+            type=edge,enable=true,branch=main
+            ## Other types (currently the followings may be out of scope in this project)
+            ## Tags for a push branch event
+            # minimal (short sha)
+            # type=sha,enable=true,format=short            
+            ## Tags for a push or pull_request event
+            # type=ref,event=branch
+            # type=ref,event=tag
+            # type=ref,event=pr
+            ## Tags for a schedule event - handlebars with timezone (e.g. 20200110-093000)
+            # type=schedule,enable=true,pattern={{date 'YYYYMMDD-hhmmss' tz='Asia/Tokyo'}}
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+        with:
+          platforms: all
+
+      - name: Set up Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Cache Docker layers
+        uses: actions/cache@v4
+        with:
+          path: /tmp/.buildx-cache
+          key: ${{ runner.os }}-buildx-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-buildx-
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
+      # TODO: Create a PAT with `read:packages` and `write:packages` scopes and save it as an Actions secret `CR_PAT`
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.CR_PAT }}
+
+      - name: Build and publish
+        id: docker_build
+        uses: docker/build-push-action@v6
+        with:
+          builder: ${{ steps.buildx.outputs.name }}
+          context: ./
+          file: ./Dockerfile
+          target: prod
+          platforms: linux/amd64 # linux/arm/v7,linux/arm64,linux/386,linux/ppc64le,linux/s390x,linux/arm/v6
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          cache-from: type=local,src=/tmp/.buildx-cache
+          cache-to: type=local,dest=/tmp/.buildx-cache
+
+      - name: Image digest
+        run: echo ${{ steps.docker_build.outputs.digest }}

--- a/.github/workflows/continuous-integration.yaml
+++ b/.github/workflows/continuous-integration.yaml
@@ -1,0 +1,65 @@
+# This workflow performs continuous integration (CI).
+# This workflow will build the container image for amd64 arch. (as a basic build test)
+name: Continuous Integration (CI)
+
+on:
+  # On pull-request event with detailed condition below.
+  pull_request:
+    branches:
+      - main
+    paths-ignore:
+      - "**.md"
+      - ".gitignore"
+      - "LICENSE"
+      - "CODEOWNERS"
+      - "assets/**"
+      - "scripts/**"
+      - "docs/**"
+      # - ".all-contributorsrc"
+      # - "src/testclient/scripts/**"
+
+jobs:
+  # The job key (i.e., ID) is "build-source-code"
+  build-source-code:
+    # Job name is "Building source code"
+    # This job runs on Ubuntu-latest (Ubuntu 22.04 LTS checked on 2023-12-13)
+    # See https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners
+    name: Build source code
+    strategy:
+      matrix:
+        go-version: ["1.21"]
+        os: [ubuntu-22.04]
+        #os: [ubuntu-22.04, ubuntu-20.04, windows-2022, windows-2019]
+    runs-on: ${{matrix.os}}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: ${{matrix.go-version}}
+
+      - name: Build
+        run: make
+
+      # - name: Test
+      #   run: go test -v ./...
+
+  # The job key is "build-container-image"
+  build-container-image:
+    # Job name is "Build a container image"
+    name: Build a container image
+
+    # This job runs on Ubuntu-latest (Ubuntu 22.04 LTS checked on 2023-12-13)
+    # See https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners
+    runs-on: ubuntu-22.04
+    if: ${{ !contains(github.event.head_commit.message, '[skip ci]') }}
+
+    steps:
+      - name: Checkout source code
+        uses: actions/checkout@v4
+
+      - name: Build image
+        env:
+          IMAGE_NAME: ${{ github.event.repository.name }}
+        run: docker build . --file Dockerfile --tag $IMAGE_NAME


### PR DESCRIPTION
* Add continuous-integration.yaml
* Add continuous-delivery.yaml

(요약 설명)

CM-Cicada에서 활용되는 외부 도구(에, Airflow)는 별도로 구동되는 것으로 가정하고, CI/CD 워크플로우를 추가하였습니다.
* 다른 서브시스템들과 다르게, CM-Cicada에는 외부 도구와 관계된 파일들이 포함되어 있어, `paths-ignore` 부분에 추가할 사항이 있으신지 주로 검토해 주시면 좋을 것 같습니다.

(Related to https://github.com/cloud-barista/cloud-migrator/issues/8)