### PR TITLE
feat: add workflow schedule and version rollback APIs

### DIFF
--- a/dao/workflow.go
+++ b/dao/workflow.go
@@ -367,3 +367,23 @@ func WorkflowVersionGet(id string, wkID string) (*model.WorkflowVersion, error) 
 
 	return workflowVersion, nil
 }
+
+// WorkflowVersionGetByNo looks up a workflow version by its sequential
+// version_no inside a workflow. Returns (nil, nil) when the row does not
+// exist so callers can distinguish "missing" from "error".
+func WorkflowVersionGetByNo(workflowID string, versionNo int) (*model.WorkflowVersion, error) {
+	if err := ensureDB(); err != nil {
+		return nil, err
+	}
+
+	workflowVersion := &model.WorkflowVersion{}
+	result := db.DB.Where("workflowId = ? AND version_no = ?", workflowID, versionNo).First(workflowVersion)
+	if result.Error != nil {
+		if errors.Is(result.Error, gorm.ErrRecordNotFound) {
+			return nil, nil
+		}
+		return nil, result.Error
+	}
+
+	return workflowVersion, nil
+}

--- a/dao/workflow_schedule.go
+++ b/dao/workflow_schedule.go
@@ -1,0 +1,84 @@
+package dao
+
+import (
+	"errors"
+
+	"gorm.io/gorm"
+
+	"github.com/cloud-barista/cm-cicada/db"
+	"github.com/cloud-barista/cm-cicada/pkg/api/rest/model"
+)
+
+// WorkflowScheduleCreate inserts a new workflow_schedules row.
+func WorkflowScheduleCreate(s *model.WorkflowSchedule) error {
+	return db.DB.Create(s).Error
+}
+
+// WorkflowScheduleGetByID returns a single schedule row by id, or nil when
+// no row matches (no error in that case).
+func WorkflowScheduleGetByID(id string) (*model.WorkflowSchedule, error) {
+	var s model.WorkflowSchedule
+	if err := db.DB.Where("id = ?", id).First(&s).Error; err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	return &s, nil
+}
+
+// WorkflowScheduleListByWorkflowID returns every schedule row attached to a
+// workflow, ordered by run_at ascending.
+func WorkflowScheduleListByWorkflowID(workflowID string) ([]model.WorkflowSchedule, error) {
+	var out []model.WorkflowSchedule
+	if err := db.DB.Where("workflow_id = ?", workflowID).
+		Order("run_at ASC").
+		Find(&out).Error; err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+// WorkflowScheduleGetLatest returns the workflow's most recently created
+// schedule row regardless of status. Used by the GET endpoint so callers
+// can see the last lifecycle state (active / executed / canceled). Returns
+// (nil, nil) when the workflow has no schedule history.
+func WorkflowScheduleGetLatest(workflowID string) (*model.WorkflowSchedule, error) {
+	var s model.WorkflowSchedule
+	err := db.DB.Where("workflow_id = ?", workflowID).
+		Order("created_at DESC").
+		First(&s).Error
+	if err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	return &s, nil
+}
+
+// WorkflowScheduleGetActive returns the single active schedule for a
+// workflow (the one that drives the DAG metadata), or nil when none exists.
+// Multiple active rows for the same workflow are not expected — service
+// layer guards against creating more than one — but if they exist this
+// returns the earliest run_at.
+func WorkflowScheduleGetActive(workflowID string) (*model.WorkflowSchedule, error) {
+	var s model.WorkflowSchedule
+	err := db.DB.Where("workflow_id = ? AND status = ?", workflowID, model.WorkflowScheduleStatusActive).
+		Order("run_at ASC").
+		First(&s).Error
+	if err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	return &s, nil
+}
+
+// WorkflowScheduleUpdateStatus transitions a schedule row to a new status.
+func WorkflowScheduleUpdateStatus(id string, status model.WorkflowScheduleStatus) error {
+	return db.DB.Model(&model.WorkflowSchedule{}).
+		Where("id = ?", id).
+		Update("status", status).Error
+}

--- a/db/sqlite.go
+++ b/db/sqlite.go
@@ -54,6 +54,11 @@ func Open() error {
 		logger.Panicln(logger.ERROR, true, err)
 	}
 
+	err = DB.AutoMigrate(&model.WorkflowSchedule{})
+	if err != nil {
+		logger.Panicln(logger.ERROR, true, err)
+	}
+
 	err = ensureWorkflowActiveNameUniqueIndex()
 	if err != nil {
 		logger.Panicln(logger.ERROR, true, err)

--- a/lib/airflow/example/workflow_template/migrate_software_workflow.json
+++ b/lib/airflow/example/workflow_template/migrate_software_workflow.json
@@ -20,7 +20,7 @@
           },
           {
             "name": "run_software_migration",
-            "task_component": "grasshopper_task_software_migration_xcom",
+            "task_component": "grasshopper_task_software_migration",
             "spec": {
               "request_body": "get_target_software_model",
               "query_params": {

--- a/lib/airflow/gusty.go
+++ b/lib/airflow/gusty.go
@@ -231,6 +231,8 @@ func ensureWorkflowDir(workflow *model.Workflow) (string, error) {
 
 func writeDAGMetadata(workflow *model.Workflow, dagDir string) error {
 	// DAG 메타데이터(METADATA.yml)를 기록한다.
+	// 워크플로우에 active schedule이 있으면 Airflow가 알아서 1회 실행하도록
+	// schedule="@once", start_date=run_at,  catchup=false 를 함께 기록한다.
 	type defaultArgs struct {
 		Owner         string `yaml:"owner"`
 		StartDate     string `yaml:"start_date"`
@@ -239,14 +241,35 @@ func writeDAGMetadata(workflow *model.Workflow, dagDir string) error {
 	}
 
 	var dagInfo struct {
-		defaultArgs    defaultArgs `yaml:"default_args"`
+		DefaultArgs    defaultArgs `yaml:"default_args"`
 		Description    string      `yaml:"description"`
 		DagDisplayName string      `yaml:"dag_display_name"`
+		Schedule       string      `yaml:"schedule,omitempty"`
+		Catchup        *bool       `yaml:"catchup,omitempty"`
 	}
 
-	dagInfo.defaultArgs = defaultArgs{
+	startDate := time.Now().Format(time.DateOnly)
+	if schedule, err := dao.WorkflowScheduleGetActive(workflow.ID); err == nil && schedule != nil {
+		switch schedule.Type {
+		case model.WorkflowScheduleTypeOnce:
+			if schedule.RunAt != nil {
+				startDate = schedule.RunAt.UTC().Format(time.RFC3339)
+				dagInfo.Schedule = "@once"
+				catchup := false
+				dagInfo.Catchup = &catchup
+			}
+		case model.WorkflowScheduleTypeCron:
+			if schedule.Cron != nil && *schedule.Cron != "" {
+				dagInfo.Schedule = *schedule.Cron
+				catchup := false
+				dagInfo.Catchup = &catchup
+			}
+		}
+	}
+
+	dagInfo.DefaultArgs = defaultArgs{
 		Owner:         strings.ToLower(common.ModuleName),
-		StartDate:     time.Now().Format(time.DateOnly),
+		StartDate:     startDate,
 		Retries:       0,
 		RetryDelaySec: 0,
 	}
@@ -664,4 +687,3 @@ func cleanupStaleTaskFilesInGroup(groupDir string, expectedTaskFilePaths map[str
 
 	return nil
 }
-

--- a/pkg/api/rest/controller/workflow_schedule.go
+++ b/pkg/api/rest/controller/workflow_schedule.go
@@ -1,0 +1,112 @@
+package controller
+
+import (
+	"net/http"
+
+	"github.com/labstack/echo/v4"
+	"github.com/mitchellh/mapstructure"
+
+	"github.com/cloud-barista/cm-cicada/pkg/api/rest/common"
+	"github.com/cloud-barista/cm-cicada/pkg/api/rest/model"
+	"github.com/cloud-barista/cm-cicada/pkg/api/rest/service"
+)
+
+// ScheduleWorkflow godoc
+//
+//	@ID		schedule-workflow
+//	@Summary	Schedule Workflow (one-shot)
+//	@Description	Register a one-shot future execution. Airflow handles the actual triggering via DAG metadata (schedule="@once" + start_date=run_at + catchup=false). Only one active schedule per workflow is allowed.
+//	@Tags		[Workflow]
+//	@Accept		json
+//	@Produce	json
+//	@Param		wfId path 	string true "Workflow ID."
+//	@Param		request body 	model.CreateWorkflowScheduleReq true "Schedule body (run_at)."
+//	@Success	200	{object}	model.WorkflowSchedule	"Successfully scheduled the workflow."
+//	@Failure	400	{object}	common.ErrorResponse	"Sent bad request."
+//	@Failure	409	{object}	common.ErrorResponse	"Active schedule already exists."
+//	@Failure	500	{object}	common.ErrorResponse	"Failed to schedule the workflow."
+//	@Router		/workflow/{wfId}/schedule [post]
+func ScheduleWorkflow(c echo.Context) error {
+	wfID := c.Param("wfId")
+	if wfID == "" {
+		return common.ReturnErrorMsg(c, "please provide the workflow id")
+	}
+
+	var req model.CreateWorkflowScheduleReq
+
+	data, err := common.GetJSONRawBody(c)
+	if err != nil {
+		return common.ReturnErrorMsg(c, err.Error())
+	}
+
+	decoder, err := mapstructure.NewDecoder(&mapstructure.DecoderConfig{
+		Metadata: nil,
+		DecodeHook: mapstructure.ComposeDecodeHookFunc(
+			toTimeHookFunc()),
+		Result: &req,
+	})
+	if err != nil {
+		return err
+	}
+	if err := decoder.Decode(data); err != nil {
+		return common.ReturnErrorMsg(c, err.Error())
+	}
+
+	svc := service.NewWorkflowScheduleService()
+	row, err := svc.Schedule(wfID, req)
+	if err != nil {
+		return common.ReturnErrorMsg(c, err.Error())
+	}
+	return c.JSONPretty(http.StatusOK, row, " ")
+}
+
+// GetWorkflowSchedule godoc
+//
+//	@ID		get-workflow-schedule
+//	@Summary	Get Workflow Schedule
+//	@Description	Return the workflow's most recently created schedule row regardless of status. Inspect .status to interpret: "active" (will fire), "executed" (already ran), "canceled" (user canceled). Returns null when the workflow has no schedule history.
+//	@Tags		[Workflow]
+//	@Produce	json
+//	@Param		wfId path 	string true "Workflow ID."
+//	@Success	200	{object}	model.WorkflowSchedule	"Latest schedule (any status), or null."
+//	@Failure	400	{object}	common.ErrorResponse	"Sent bad request."
+//	@Failure	500	{object}	common.ErrorResponse	"Failed to fetch the schedule."
+//	@Router		/workflow/{wfId}/schedule [get]
+func GetWorkflowSchedule(c echo.Context) error {
+	wfID := c.Param("wfId")
+	if wfID == "" {
+		return common.ReturnErrorMsg(c, "please provide the workflow id")
+	}
+	svc := service.NewWorkflowScheduleService()
+	row, err := svc.GetLatest(wfID)
+	if err != nil {
+		return common.ReturnErrorMsg(c, err.Error())
+	}
+	return c.JSONPretty(http.StatusOK, row, " ")
+}
+
+// CancelWorkflowSchedule godoc
+//
+//	@ID		cancel-workflow-schedule
+//	@Summary	Cancel Workflow Schedule
+//	@Description	Cancel the workflow's active schedule. The DAG metadata is rewritten so Airflow no longer triggers the workflow on the originally requested cadence. Returns 404 when no active schedule exists.
+//	@Tags		[Workflow]
+//	@Produce	json
+//	@Param		wfId path 	string true "Workflow ID."
+//	@Success	200	{object}	model.WorkflowSchedule	"Successfully canceled."
+//	@Failure	400	{object}	common.ErrorResponse	"Sent bad request."
+//	@Failure	404	{object}	common.ErrorResponse	"No active schedule for this workflow."
+//	@Failure	500	{object}	common.ErrorResponse	"Failed to cancel the schedule."
+//	@Router		/workflow/{wfId}/schedule [delete]
+func CancelWorkflowSchedule(c echo.Context) error {
+	wfID := c.Param("wfId")
+	if wfID == "" {
+		return common.ReturnErrorMsg(c, "please provide the workflow id")
+	}
+	svc := service.NewWorkflowScheduleService()
+	row, err := svc.Cancel(wfID)
+	if err != nil {
+		return common.ReturnErrorMsg(c, err.Error())
+	}
+	return c.JSONPretty(http.StatusOK, row, " ")
+}

--- a/pkg/api/rest/controller/workflow_version.go
+++ b/pkg/api/rest/controller/workflow_version.go
@@ -2,6 +2,7 @@ package controller
 
 import (
 	"net/http"
+	"strconv"
 
 	"github.com/cloud-barista/cm-cicada/pkg/api/rest/common"
 	"github.com/cloud-barista/cm-cicada/pkg/api/rest/model"
@@ -77,4 +78,39 @@ func GetWorkflowVersion(c echo.Context) error {
 	}
 
 	return c.JSONPretty(http.StatusOK, version, " ")
+}
+
+// RollbackWorkflow godoc
+//
+//	@ID		rollback-workflow
+//	@Summary	Rollback Workflow to a Past Version
+//	@Description	Restore the workflow's task graph and metadata from the snapshot identified by versionNo. Existing active tasks are soft-deleted and re-issued with fresh UUIDs from the target version's raw_data. The rollback itself is recorded as a new WorkflowVersion with action="rollback" and source_template_id=<source version id>. workflow_schedules rows are left untouched.
+//	@Tags		[Workflow]
+//	@Produce	json
+//	@Param		wfId path 	string true "Workflow ID."
+//	@Param		versionNo path 	int true "Target version_no within the workflow (1-based, positive integer)."
+//	@Success	200	{object}	model.Workflow		"Workflow after rollback."
+//	@Failure	400	{object}	common.ErrorResponse	"Sent bad request."
+//	@Failure	404	{object}	common.ErrorResponse	"Workflow or version not found."
+//	@Failure	409	{object}	common.ErrorResponse	"Cannot rollback to this version (e.g. delete action)."
+//	@Failure	500	{object}	common.ErrorResponse	"Failed to rollback the workflow."
+//	@Router		/workflow/{wfId}/version/{versionNo}/rollback [post]
+func RollbackWorkflow(c echo.Context) error {
+	wfId, err := requireParam(c, "wfId", "wfId")
+	if err != nil {
+		return common.ReturnErrorMsg(c, err.Error())
+	}
+	versionNoStr := c.Param("versionNo")
+	versionNo, err := strconv.Atoi(versionNoStr)
+	if err != nil || versionNo <= 0 {
+		return common.ReturnErrorMsg(c, "version_no must be a positive integer")
+	}
+
+	svc := service.NewWorkflowService()
+	workflow, err := svc.RollbackWorkflow(wfId, versionNo)
+	if err != nil {
+		return common.ReturnErrorMsg(c, err.Error())
+	}
+
+	return c.JSONPretty(http.StatusOK, workflow, " ")
 }

--- a/pkg/api/rest/docs/docs.go
+++ b/pkg/api/rest/docs/docs.go
@@ -2031,6 +2031,67 @@ const docTemplate = `{
                 }
             }
         },
+        "/workflow/{wfId}/version/{versionNo}/rollback": {
+            "post": {
+                "description": "Restore the workflow's task graph and metadata from the snapshot identified by versionNo. Existing active tasks are soft-deleted and re-issued with fresh UUIDs from the target version's raw_data. The rollback itself is recorded as a new WorkflowVersion with action=\"rollback\" and source_template_id=\u003csource version id\u003e. workflow_schedules rows are left untouched.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "[Workflow]"
+                ],
+                "summary": "Rollback Workflow to a Past Version",
+                "operationId": "rollback-workflow",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Workflow ID.",
+                        "name": "wfId",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Target version_no within the workflow (1-based, positive integer).",
+                        "name": "versionNo",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Workflow after rollback.",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_cloud-barista_cm-cicada_pkg_api_rest_model.Workflow"
+                        }
+                    },
+                    "400": {
+                        "description": "Sent bad request.",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_cloud-barista_cm-cicada_pkg_api_rest_common.ErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Workflow or version not found.",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_cloud-barista_cm-cicada_pkg_api_rest_common.ErrorResponse"
+                        }
+                    },
+                    "409": {
+                        "description": "Cannot rollback to this version (e.g. delete action).",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_cloud-barista_cm-cicada_pkg_api_rest_common.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Failed to rollback the workflow.",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_cloud-barista_cm-cicada_pkg_api_rest_common.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/workflow/{wfId}/workflowRun/{wfRunId}/range": {
             "post": {
                 "description": "Clear the task Instance.",

--- a/pkg/api/rest/docs/docs.go
+++ b/pkg/api/rest/docs/docs.go
@@ -1212,10 +1212,7 @@ const docTemplate = `{
         },
         "/workflow/{wfId}/clone": {
             "post": {
-                "description": "Clone an existing workflow as a new workflow. The server copies task_groups / tasks from the source (looked up by wfId) and re-issues all IDs. The first snapshot of the new workflow records source_type=\"clone\" and source_template_id=\u003csource workflow id\u003e.",
-                "consumes": [
-                    "application/json"
-                ],
+                "description": "Clone an existing workflow as a new workflow. The server copies task_groups / tasks from the source (looked up by wfId) and re-issues all IDs. The new workflow's name is auto-generated as \"\u003csource name\u003e_copy\" (with _copy_2, _copy_3 ... on collision). The first snapshot of the new workflow records source_type=\"clone\" and source_template_id=\u003csource workflow id\u003e.",
                 "produces": [
                     "application/json"
                 ],
@@ -1231,15 +1228,6 @@ const docTemplate = `{
                         "name": "wfId",
                         "in": "path",
                         "required": true
-                    },
-                    {
-                        "description": "New workflow name (and optional description override).",
-                        "name": "request",
-                        "in": "body",
-                        "required": true,
-                        "schema": {
-                            "$ref": "#/definitions/github_com_cloud-barista_cm-cicada_pkg_api_rest_model.CloneWorkflowReq"
-                        }
                     }
                 ],
                 "responses": {
@@ -1416,6 +1404,152 @@ const docTemplate = `{
                     },
                     "500": {
                         "description": "Failed to get the workflowRuns.",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_cloud-barista_cm-cicada_pkg_api_rest_common.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/workflow/{wfId}/schedule": {
+            "get": {
+                "description": "Return the workflow's most recently created schedule row regardless of status. Inspect .status to interpret: \"active\" (will fire), \"executed\" (already ran), \"canceled\" (user canceled). Returns null when the workflow has no schedule history.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "[Workflow]"
+                ],
+                "summary": "Get Workflow Schedule",
+                "operationId": "get-workflow-schedule",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Workflow ID.",
+                        "name": "wfId",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Latest schedule (any status), or null.",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_cloud-barista_cm-cicada_pkg_api_rest_model.WorkflowSchedule"
+                        }
+                    },
+                    "400": {
+                        "description": "Sent bad request.",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_cloud-barista_cm-cicada_pkg_api_rest_common.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Failed to fetch the schedule.",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_cloud-barista_cm-cicada_pkg_api_rest_common.ErrorResponse"
+                        }
+                    }
+                }
+            },
+            "post": {
+                "description": "Register a one-shot future execution. Airflow handles the actual triggering via DAG metadata (schedule=\"@once\" + start_date=run_at + catchup=false). Only one active schedule per workflow is allowed.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "[Workflow]"
+                ],
+                "summary": "Schedule Workflow (one-shot)",
+                "operationId": "schedule-workflow",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Workflow ID.",
+                        "name": "wfId",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Schedule body (run_at).",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/github_com_cloud-barista_cm-cicada_pkg_api_rest_model.CreateWorkflowScheduleReq"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successfully scheduled the workflow.",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_cloud-barista_cm-cicada_pkg_api_rest_model.WorkflowSchedule"
+                        }
+                    },
+                    "400": {
+                        "description": "Sent bad request.",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_cloud-barista_cm-cicada_pkg_api_rest_common.ErrorResponse"
+                        }
+                    },
+                    "409": {
+                        "description": "Active schedule already exists.",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_cloud-barista_cm-cicada_pkg_api_rest_common.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Failed to schedule the workflow.",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_cloud-barista_cm-cicada_pkg_api_rest_common.ErrorResponse"
+                        }
+                    }
+                }
+            },
+            "delete": {
+                "description": "Cancel the workflow's active schedule. The DAG metadata is rewritten so Airflow no longer triggers the workflow on the originally requested cadence. Returns 404 when no active schedule exists.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "[Workflow]"
+                ],
+                "summary": "Cancel Workflow Schedule",
+                "operationId": "cancel-workflow-schedule",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Workflow ID.",
+                        "name": "wfId",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successfully canceled.",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_cloud-barista_cm-cicada_pkg_api_rest_model.WorkflowSchedule"
+                        }
+                    },
+                    "400": {
+                        "description": "Sent bad request.",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_cloud-barista_cm-cicada_pkg_api_rest_common.ErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "No active schedule for this workflow.",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_cloud-barista_cm-cicada_pkg_api_rest_common.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Failed to cancel the schedule.",
                         "schema": {
                             "$ref": "#/definitions/github_com_cloud-barista_cm-cicada_pkg_api_rest_common.ErrorResponse"
                         }
@@ -2400,20 +2534,6 @@ const docTemplate = `{
                 }
             }
         },
-        "github_com_cloud-barista_cm-cicada_pkg_api_rest_model.CloneWorkflowReq": {
-            "type": "object",
-            "required": [
-                "name"
-            ],
-            "properties": {
-                "description": {
-                    "type": "string"
-                },
-                "name": {
-                    "type": "string"
-                }
-            }
-        },
         "github_com_cloud-barista_cm-cicada_pkg_api_rest_model.Connection": {
             "type": "object",
             "required": [
@@ -2548,6 +2668,17 @@ const docTemplate = `{
                     "type": "string"
                 },
                 "spec_version": {
+                    "type": "string"
+                }
+            }
+        },
+        "github_com_cloud-barista_cm-cicada_pkg_api_rest_model.CreateWorkflowScheduleReq": {
+            "type": "object",
+            "properties": {
+                "cron": {
+                    "type": "string"
+                },
+                "run_at": {
                     "type": "string"
                 }
             }
@@ -2985,6 +3116,59 @@ const docTemplate = `{
                     "type": "string"
                 }
             }
+        },
+        "github_com_cloud-barista_cm-cicada_pkg_api_rest_model.WorkflowSchedule": {
+            "type": "object",
+            "properties": {
+                "created_at": {
+                    "type": "string"
+                },
+                "cron": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "run_at": {
+                    "type": "string"
+                },
+                "status": {
+                    "$ref": "#/definitions/github_com_cloud-barista_cm-cicada_pkg_api_rest_model.WorkflowScheduleStatus"
+                },
+                "type": {
+                    "$ref": "#/definitions/github_com_cloud-barista_cm-cicada_pkg_api_rest_model.WorkflowScheduleType"
+                },
+                "updated_at": {
+                    "type": "string"
+                },
+                "workflow_id": {
+                    "type": "string"
+                }
+            }
+        },
+        "github_com_cloud-barista_cm-cicada_pkg_api_rest_model.WorkflowScheduleStatus": {
+            "type": "string",
+            "enum": [
+                "active",
+                "canceled",
+                "executed"
+            ],
+            "x-enum-varnames": [
+                "WorkflowScheduleStatusActive",
+                "WorkflowScheduleStatusCanceled",
+                "WorkflowScheduleStatusExecuted"
+            ]
+        },
+        "github_com_cloud-barista_cm-cicada_pkg_api_rest_model.WorkflowScheduleType": {
+            "type": "string",
+            "enum": [
+                "once",
+                "cron"
+            ],
+            "x-enum-varnames": [
+                "WorkflowScheduleTypeOnce",
+                "WorkflowScheduleTypeCron"
+            ]
         },
         "github_com_cloud-barista_cm-cicada_pkg_api_rest_model.WorkflowStatus": {
             "type": "object",

--- a/pkg/api/rest/docs/swagger.json
+++ b/pkg/api/rest/docs/swagger.json
@@ -2024,6 +2024,67 @@
                 }
             }
         },
+        "/workflow/{wfId}/version/{versionNo}/rollback": {
+            "post": {
+                "description": "Restore the workflow's task graph and metadata from the snapshot identified by versionNo. Existing active tasks are soft-deleted and re-issued with fresh UUIDs from the target version's raw_data. The rollback itself is recorded as a new WorkflowVersion with action=\"rollback\" and source_template_id=\u003csource version id\u003e. workflow_schedules rows are left untouched.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "[Workflow]"
+                ],
+                "summary": "Rollback Workflow to a Past Version",
+                "operationId": "rollback-workflow",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Workflow ID.",
+                        "name": "wfId",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Target version_no within the workflow (1-based, positive integer).",
+                        "name": "versionNo",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Workflow after rollback.",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_cloud-barista_cm-cicada_pkg_api_rest_model.Workflow"
+                        }
+                    },
+                    "400": {
+                        "description": "Sent bad request.",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_cloud-barista_cm-cicada_pkg_api_rest_common.ErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Workflow or version not found.",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_cloud-barista_cm-cicada_pkg_api_rest_common.ErrorResponse"
+                        }
+                    },
+                    "409": {
+                        "description": "Cannot rollback to this version (e.g. delete action).",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_cloud-barista_cm-cicada_pkg_api_rest_common.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Failed to rollback the workflow.",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_cloud-barista_cm-cicada_pkg_api_rest_common.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/workflow/{wfId}/workflowRun/{wfRunId}/range": {
             "post": {
                 "description": "Clear the task Instance.",

--- a/pkg/api/rest/docs/swagger.json
+++ b/pkg/api/rest/docs/swagger.json
@@ -1205,10 +1205,7 @@
         },
         "/workflow/{wfId}/clone": {
             "post": {
-                "description": "Clone an existing workflow as a new workflow. The server copies task_groups / tasks from the source (looked up by wfId) and re-issues all IDs. The first snapshot of the new workflow records source_type=\"clone\" and source_template_id=\u003csource workflow id\u003e.",
-                "consumes": [
-                    "application/json"
-                ],
+                "description": "Clone an existing workflow as a new workflow. The server copies task_groups / tasks from the source (looked up by wfId) and re-issues all IDs. The new workflow's name is auto-generated as \"\u003csource name\u003e_copy\" (with _copy_2, _copy_3 ... on collision). The first snapshot of the new workflow records source_type=\"clone\" and source_template_id=\u003csource workflow id\u003e.",
                 "produces": [
                     "application/json"
                 ],
@@ -1224,15 +1221,6 @@
                         "name": "wfId",
                         "in": "path",
                         "required": true
-                    },
-                    {
-                        "description": "New workflow name (and optional description override).",
-                        "name": "request",
-                        "in": "body",
-                        "required": true,
-                        "schema": {
-                            "$ref": "#/definitions/github_com_cloud-barista_cm-cicada_pkg_api_rest_model.CloneWorkflowReq"
-                        }
                     }
                 ],
                 "responses": {
@@ -1409,6 +1397,152 @@
                     },
                     "500": {
                         "description": "Failed to get the workflowRuns.",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_cloud-barista_cm-cicada_pkg_api_rest_common.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/workflow/{wfId}/schedule": {
+            "get": {
+                "description": "Return the workflow's most recently created schedule row regardless of status. Inspect .status to interpret: \"active\" (will fire), \"executed\" (already ran), \"canceled\" (user canceled). Returns null when the workflow has no schedule history.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "[Workflow]"
+                ],
+                "summary": "Get Workflow Schedule",
+                "operationId": "get-workflow-schedule",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Workflow ID.",
+                        "name": "wfId",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Latest schedule (any status), or null.",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_cloud-barista_cm-cicada_pkg_api_rest_model.WorkflowSchedule"
+                        }
+                    },
+                    "400": {
+                        "description": "Sent bad request.",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_cloud-barista_cm-cicada_pkg_api_rest_common.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Failed to fetch the schedule.",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_cloud-barista_cm-cicada_pkg_api_rest_common.ErrorResponse"
+                        }
+                    }
+                }
+            },
+            "post": {
+                "description": "Register a one-shot future execution. Airflow handles the actual triggering via DAG metadata (schedule=\"@once\" + start_date=run_at + catchup=false). Only one active schedule per workflow is allowed.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "[Workflow]"
+                ],
+                "summary": "Schedule Workflow (one-shot)",
+                "operationId": "schedule-workflow",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Workflow ID.",
+                        "name": "wfId",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Schedule body (run_at).",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/github_com_cloud-barista_cm-cicada_pkg_api_rest_model.CreateWorkflowScheduleReq"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successfully scheduled the workflow.",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_cloud-barista_cm-cicada_pkg_api_rest_model.WorkflowSchedule"
+                        }
+                    },
+                    "400": {
+                        "description": "Sent bad request.",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_cloud-barista_cm-cicada_pkg_api_rest_common.ErrorResponse"
+                        }
+                    },
+                    "409": {
+                        "description": "Active schedule already exists.",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_cloud-barista_cm-cicada_pkg_api_rest_common.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Failed to schedule the workflow.",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_cloud-barista_cm-cicada_pkg_api_rest_common.ErrorResponse"
+                        }
+                    }
+                }
+            },
+            "delete": {
+                "description": "Cancel the workflow's active schedule. The DAG metadata is rewritten so Airflow no longer triggers the workflow on the originally requested cadence. Returns 404 when no active schedule exists.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "[Workflow]"
+                ],
+                "summary": "Cancel Workflow Schedule",
+                "operationId": "cancel-workflow-schedule",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Workflow ID.",
+                        "name": "wfId",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successfully canceled.",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_cloud-barista_cm-cicada_pkg_api_rest_model.WorkflowSchedule"
+                        }
+                    },
+                    "400": {
+                        "description": "Sent bad request.",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_cloud-barista_cm-cicada_pkg_api_rest_common.ErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "No active schedule for this workflow.",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_cloud-barista_cm-cicada_pkg_api_rest_common.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Failed to cancel the schedule.",
                         "schema": {
                             "$ref": "#/definitions/github_com_cloud-barista_cm-cicada_pkg_api_rest_common.ErrorResponse"
                         }
@@ -2393,20 +2527,6 @@
                 }
             }
         },
-        "github_com_cloud-barista_cm-cicada_pkg_api_rest_model.CloneWorkflowReq": {
-            "type": "object",
-            "required": [
-                "name"
-            ],
-            "properties": {
-                "description": {
-                    "type": "string"
-                },
-                "name": {
-                    "type": "string"
-                }
-            }
-        },
         "github_com_cloud-barista_cm-cicada_pkg_api_rest_model.Connection": {
             "type": "object",
             "required": [
@@ -2541,6 +2661,17 @@
                     "type": "string"
                 },
                 "spec_version": {
+                    "type": "string"
+                }
+            }
+        },
+        "github_com_cloud-barista_cm-cicada_pkg_api_rest_model.CreateWorkflowScheduleReq": {
+            "type": "object",
+            "properties": {
+                "cron": {
+                    "type": "string"
+                },
+                "run_at": {
                     "type": "string"
                 }
             }
@@ -2978,6 +3109,59 @@
                     "type": "string"
                 }
             }
+        },
+        "github_com_cloud-barista_cm-cicada_pkg_api_rest_model.WorkflowSchedule": {
+            "type": "object",
+            "properties": {
+                "created_at": {
+                    "type": "string"
+                },
+                "cron": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "run_at": {
+                    "type": "string"
+                },
+                "status": {
+                    "$ref": "#/definitions/github_com_cloud-barista_cm-cicada_pkg_api_rest_model.WorkflowScheduleStatus"
+                },
+                "type": {
+                    "$ref": "#/definitions/github_com_cloud-barista_cm-cicada_pkg_api_rest_model.WorkflowScheduleType"
+                },
+                "updated_at": {
+                    "type": "string"
+                },
+                "workflow_id": {
+                    "type": "string"
+                }
+            }
+        },
+        "github_com_cloud-barista_cm-cicada_pkg_api_rest_model.WorkflowScheduleStatus": {
+            "type": "string",
+            "enum": [
+                "active",
+                "canceled",
+                "executed"
+            ],
+            "x-enum-varnames": [
+                "WorkflowScheduleStatusActive",
+                "WorkflowScheduleStatusCanceled",
+                "WorkflowScheduleStatusExecuted"
+            ]
+        },
+        "github_com_cloud-barista_cm-cicada_pkg_api_rest_model.WorkflowScheduleType": {
+            "type": "string",
+            "enum": [
+                "once",
+                "cron"
+            ],
+            "x-enum-varnames": [
+                "WorkflowScheduleTypeOnce",
+                "WorkflowScheduleTypeCron"
+            ]
         },
         "github_com_cloud-barista_cm-cicada_pkg_api_rest_model.WorkflowStatus": {
             "type": "object",

--- a/pkg/api/rest/docs/swagger.yaml
+++ b/pkg/api/rest/docs/swagger.yaml
@@ -1891,6 +1891,51 @@ paths:
       summary: Get Workflow Version
       tags:
       - '[Workflow]'
+  /workflow/{wfId}/version/{versionNo}/rollback:
+    post:
+      description: Restore the workflow's task graph and metadata from the snapshot
+        identified by versionNo. Existing active tasks are soft-deleted and re-issued
+        with fresh UUIDs from the target version's raw_data. The rollback itself is
+        recorded as a new WorkflowVersion with action="rollback" and source_template_id=<source
+        version id>. workflow_schedules rows are left untouched.
+      operationId: rollback-workflow
+      parameters:
+      - description: Workflow ID.
+        in: path
+        name: wfId
+        required: true
+        type: string
+      - description: Target version_no within the workflow (1-based, positive integer).
+        in: path
+        name: versionNo
+        required: true
+        type: integer
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: Workflow after rollback.
+          schema:
+            $ref: '#/definitions/github_com_cloud-barista_cm-cicada_pkg_api_rest_model.Workflow'
+        "400":
+          description: Sent bad request.
+          schema:
+            $ref: '#/definitions/github_com_cloud-barista_cm-cicada_pkg_api_rest_common.ErrorResponse'
+        "404":
+          description: Workflow or version not found.
+          schema:
+            $ref: '#/definitions/github_com_cloud-barista_cm-cicada_pkg_api_rest_common.ErrorResponse'
+        "409":
+          description: Cannot rollback to this version (e.g. delete action).
+          schema:
+            $ref: '#/definitions/github_com_cloud-barista_cm-cicada_pkg_api_rest_common.ErrorResponse'
+        "500":
+          description: Failed to rollback the workflow.
+          schema:
+            $ref: '#/definitions/github_com_cloud-barista_cm-cicada_pkg_api_rest_common.ErrorResponse'
+      summary: Rollback Workflow to a Past Version
+      tags:
+      - '[Workflow]'
   /workflow/{wfId}/workflowRun/{wfRunId}/range:
     post:
       consumes:

--- a/pkg/api/rest/docs/swagger.yaml
+++ b/pkg/api/rest/docs/swagger.yaml
@@ -71,15 +71,6 @@ definitions:
       error:
         type: string
     type: object
-  github_com_cloud-barista_cm-cicada_pkg_api_rest_model.CloneWorkflowReq:
-    properties:
-      description:
-        type: string
-      name:
-        type: string
-    required:
-    - name
-    type: object
   github_com_cloud-barista_cm-cicada_pkg_api_rest_model.Connection:
     properties:
       description:
@@ -171,6 +162,13 @@ definitions:
     required:
     - data
     - name
+    type: object
+  github_com_cloud-barista_cm-cicada_pkg_api_rest_model.CreateWorkflowScheduleReq:
+    properties:
+      cron:
+        type: string
+      run_at:
+        type: string
     type: object
   github_com_cloud-barista_cm-cicada_pkg_api_rest_model.Data:
     properties:
@@ -469,6 +467,43 @@ definitions:
       workflow_run_id:
         type: string
     type: object
+  github_com_cloud-barista_cm-cicada_pkg_api_rest_model.WorkflowSchedule:
+    properties:
+      created_at:
+        type: string
+      cron:
+        type: string
+      id:
+        type: string
+      run_at:
+        type: string
+      status:
+        $ref: '#/definitions/github_com_cloud-barista_cm-cicada_pkg_api_rest_model.WorkflowScheduleStatus'
+      type:
+        $ref: '#/definitions/github_com_cloud-barista_cm-cicada_pkg_api_rest_model.WorkflowScheduleType'
+      updated_at:
+        type: string
+      workflow_id:
+        type: string
+    type: object
+  github_com_cloud-barista_cm-cicada_pkg_api_rest_model.WorkflowScheduleStatus:
+    enum:
+    - active
+    - canceled
+    - executed
+    type: string
+    x-enum-varnames:
+    - WorkflowScheduleStatusActive
+    - WorkflowScheduleStatusCanceled
+    - WorkflowScheduleStatusExecuted
+  github_com_cloud-barista_cm-cicada_pkg_api_rest_model.WorkflowScheduleType:
+    enum:
+    - once
+    - cron
+    type: string
+    x-enum-varnames:
+    - WorkflowScheduleTypeOnce
+    - WorkflowScheduleTypeCron
   github_com_cloud-barista_cm-cicada_pkg_api_rest_model.WorkflowStatus:
     properties:
       count:
@@ -1297,12 +1332,11 @@ paths:
       - '[Workflow]'
   /workflow/{wfId}/clone:
     post:
-      consumes:
-      - application/json
       description: Clone an existing workflow as a new workflow. The server copies
         task_groups / tasks from the source (looked up by wfId) and re-issues all
-        IDs. The first snapshot of the new workflow records source_type="clone" and
-        source_template_id=<source workflow id>.
+        IDs. The new workflow's name is auto-generated as "<source name>_copy" (with
+        _copy_2, _copy_3 ... on collision). The first snapshot of the new workflow
+        records source_type="clone" and source_template_id=<source workflow id>.
       operationId: clone-workflow
       parameters:
       - description: ID of the source workflow to clone.
@@ -1310,12 +1344,6 @@ paths:
         name: wfId
         required: true
         type: string
-      - description: New workflow name (and optional description override).
-        in: body
-        name: request
-        required: true
-        schema:
-          $ref: '#/definitions/github_com_cloud-barista_cm-cicada_pkg_api_rest_model.CloneWorkflowReq'
       produces:
       - application/json
       responses:
@@ -1440,6 +1468,111 @@ paths:
       summary: List Workflow Runs
       tags:
       - '[Workflow Execution]'
+  /workflow/{wfId}/schedule:
+    delete:
+      description: Cancel the workflow's active schedule. The DAG metadata is rewritten
+        so Airflow no longer triggers the workflow on the originally requested cadence.
+        Returns 404 when no active schedule exists.
+      operationId: cancel-workflow-schedule
+      parameters:
+      - description: Workflow ID.
+        in: path
+        name: wfId
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: Successfully canceled.
+          schema:
+            $ref: '#/definitions/github_com_cloud-barista_cm-cicada_pkg_api_rest_model.WorkflowSchedule'
+        "400":
+          description: Sent bad request.
+          schema:
+            $ref: '#/definitions/github_com_cloud-barista_cm-cicada_pkg_api_rest_common.ErrorResponse'
+        "404":
+          description: No active schedule for this workflow.
+          schema:
+            $ref: '#/definitions/github_com_cloud-barista_cm-cicada_pkg_api_rest_common.ErrorResponse'
+        "500":
+          description: Failed to cancel the schedule.
+          schema:
+            $ref: '#/definitions/github_com_cloud-barista_cm-cicada_pkg_api_rest_common.ErrorResponse'
+      summary: Cancel Workflow Schedule
+      tags:
+      - '[Workflow]'
+    get:
+      description: 'Return the workflow''s most recently created schedule row regardless
+        of status. Inspect .status to interpret: "active" (will fire), "executed"
+        (already ran), "canceled" (user canceled). Returns null when the workflow
+        has no schedule history.'
+      operationId: get-workflow-schedule
+      parameters:
+      - description: Workflow ID.
+        in: path
+        name: wfId
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: Latest schedule (any status), or null.
+          schema:
+            $ref: '#/definitions/github_com_cloud-barista_cm-cicada_pkg_api_rest_model.WorkflowSchedule'
+        "400":
+          description: Sent bad request.
+          schema:
+            $ref: '#/definitions/github_com_cloud-barista_cm-cicada_pkg_api_rest_common.ErrorResponse'
+        "500":
+          description: Failed to fetch the schedule.
+          schema:
+            $ref: '#/definitions/github_com_cloud-barista_cm-cicada_pkg_api_rest_common.ErrorResponse'
+      summary: Get Workflow Schedule
+      tags:
+      - '[Workflow]'
+    post:
+      consumes:
+      - application/json
+      description: Register a one-shot future execution. Airflow handles the actual
+        triggering via DAG metadata (schedule="@once" + start_date=run_at + catchup=false).
+        Only one active schedule per workflow is allowed.
+      operationId: schedule-workflow
+      parameters:
+      - description: Workflow ID.
+        in: path
+        name: wfId
+        required: true
+        type: string
+      - description: Schedule body (run_at).
+        in: body
+        name: request
+        required: true
+        schema:
+          $ref: '#/definitions/github_com_cloud-barista_cm-cicada_pkg_api_rest_model.CreateWorkflowScheduleReq'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: Successfully scheduled the workflow.
+          schema:
+            $ref: '#/definitions/github_com_cloud-barista_cm-cicada_pkg_api_rest_model.WorkflowSchedule'
+        "400":
+          description: Sent bad request.
+          schema:
+            $ref: '#/definitions/github_com_cloud-barista_cm-cicada_pkg_api_rest_common.ErrorResponse'
+        "409":
+          description: Active schedule already exists.
+          schema:
+            $ref: '#/definitions/github_com_cloud-barista_cm-cicada_pkg_api_rest_common.ErrorResponse'
+        "500":
+          description: Failed to schedule the workflow.
+          schema:
+            $ref: '#/definitions/github_com_cloud-barista_cm-cicada_pkg_api_rest_common.ErrorResponse'
+      summary: Schedule Workflow (one-shot)
+      tags:
+      - '[Workflow]'
   /workflow/{wfId}/status:
     get:
       consumes:

--- a/pkg/api/rest/model/workflow_schedule.go
+++ b/pkg/api/rest/model/workflow_schedule.go
@@ -1,0 +1,58 @@
+package model
+
+import "time"
+
+// WorkflowScheduleStatus is the lifecycle state of a WorkflowSchedule row.
+// Transitions: active -> canceled (user cancel) | active -> executed
+// (Airflow ran it; only applies to type="once" — cron schedules stay active
+// until canceled).
+type WorkflowScheduleStatus string
+
+const (
+	WorkflowScheduleStatusActive   WorkflowScheduleStatus = "active"
+	WorkflowScheduleStatusCanceled WorkflowScheduleStatus = "canceled"
+	WorkflowScheduleStatusExecuted WorkflowScheduleStatus = "executed"
+)
+
+// WorkflowScheduleType discriminates one-shot vs recurring schedules.
+type WorkflowScheduleType string
+
+const (
+	WorkflowScheduleTypeOnce WorkflowScheduleType = "once"
+	WorkflowScheduleTypeCron WorkflowScheduleType = "cron"
+)
+
+// WorkflowSchedule records a scheduled execution of a workflow. The actual
+// scheduling is delegated to Airflow via DAG metadata — cm-cicada only
+// persists the intent so it survives restarts and is queryable.
+//
+// One of RunAt / Cron is set depending on Type:
+//   - Type="once": RunAt set, Cron nil. Airflow gets schedule="@once" +
+//     start_date=RunAt + catchup=false.
+//   - Type="cron": Cron set, RunAt nil. Airflow gets schedule=<cron> +
+//     catchup=false.
+//
+// At most one row per workflow_id is in active state at a time, regardless
+// of type, because the Airflow DAG only carries a single schedule value.
+type WorkflowSchedule struct {
+	ID         string                 `gorm:"primaryKey;column:id" json:"id"`
+	WorkflowID string                 `gorm:"column:workflow_id;index;not null" json:"workflow_id"`
+	Type       WorkflowScheduleType   `gorm:"column:type;not null;default:once" json:"type"`
+	RunAt      *time.Time             `gorm:"column:run_at" json:"run_at,omitempty"`
+	Cron       *string                `gorm:"column:cron" json:"cron,omitempty"`
+	Status     WorkflowScheduleStatus `gorm:"column:status;not null;default:active" json:"status"`
+	CreatedAt  time.Time              `gorm:"autoCreateTime" json:"created_at"`
+	UpdatedAt  time.Time              `gorm:"autoUpdateTime" json:"updated_at"`
+}
+
+func (WorkflowSchedule) TableName() string {
+	return "workflow_schedules"
+}
+
+// CreateWorkflowScheduleReq is the body for POST /workflow/{wfId}/schedule.
+// Exactly one of RunAt / Cron must be provided. RunAt creates a one-shot
+// schedule, Cron creates a recurring schedule.
+type CreateWorkflowScheduleReq struct {
+	RunAt *time.Time `json:"run_at,omitempty" mapstructure:"run_at"`
+	Cron  *string    `json:"cron,omitempty" mapstructure:"cron"`
+}

--- a/pkg/api/rest/route/workflow.go
+++ b/pkg/api/rest/route/workflow.go
@@ -41,6 +41,7 @@ func Workflow(e *echo.Echo) {
 	e.GET("/"+strings.ToLower(common.ShortModuleName)+"/importErrors", controller.GetImportErrors)
 	e.GET("/"+strings.ToLower(common.ShortModuleName)+"/workflow/:wfId/version", controller.ListWorkflowVersion)
 	e.GET("/"+strings.ToLower(common.ShortModuleName)+"/workflow/:wfId/version/:verId", controller.GetWorkflowVersion)
+	e.POST("/"+strings.ToLower(common.ShortModuleName)+"/workflow/:wfId/version/:versionNo/rollback", controller.RollbackWorkflow)
 	e.GET("/"+strings.ToLower(common.ShortModuleName)+"/workflow/:wfId/status", controller.GetWorkflowStatus)
 
 	e.POST("/"+strings.ToLower(common.ShortModuleName)+"/run_script", controller.RunScript)

--- a/pkg/api/rest/route/workflow.go
+++ b/pkg/api/rest/route/workflow.go
@@ -16,6 +16,9 @@ func Workflow(e *echo.Echo) {
 	e.PUT("/"+strings.ToLower(common.ShortModuleName)+"/workflow/:wfId", controller.UpdateWorkflow)
 	e.POST("/"+strings.ToLower(common.ShortModuleName)+"/workflow/:wfId/run", controller.RunWorkflow)
 	e.POST("/"+strings.ToLower(common.ShortModuleName)+"/workflow/:wfId/clone", controller.CloneWorkflow)
+	e.POST("/"+strings.ToLower(common.ShortModuleName)+"/workflow/:wfId/schedule", controller.ScheduleWorkflow)
+	e.GET("/"+strings.ToLower(common.ShortModuleName)+"/workflow/:wfId/schedule", controller.GetWorkflowSchedule)
+	e.DELETE("/"+strings.ToLower(common.ShortModuleName)+"/workflow/:wfId/schedule", controller.CancelWorkflowSchedule)
 	e.DELETE("/"+strings.ToLower(common.ShortModuleName)+"/workflow/:wfId", controller.DeleteWorkflow)
 
 	e.GET("/"+strings.ToLower(common.ShortModuleName)+"/workflow/:wfId/task_group", controller.ListTaskGroup)

--- a/pkg/api/rest/service/workflow_schedule_service.go
+++ b/pkg/api/rest/service/workflow_schedule_service.go
@@ -1,0 +1,203 @@
+package service
+
+import (
+	"errors"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/cloud-barista/cm-cicada/dao"
+	"github.com/cloud-barista/cm-cicada/lib/airflow"
+	"github.com/cloud-barista/cm-cicada/pkg/api/rest/common"
+	"github.com/cloud-barista/cm-cicada/pkg/api/rest/mapper"
+	"github.com/cloud-barista/cm-cicada/pkg/api/rest/model"
+)
+
+type WorkflowScheduleService struct{}
+
+func NewWorkflowScheduleService() *WorkflowScheduleService {
+	return &WorkflowScheduleService{}
+}
+
+// Schedule registers a scheduled execution. Exactly one of req.RunAt /
+// req.Cron must be set:
+//   - RunAt: one-shot future execution (Airflow schedule="@once" + start_date).
+//   - Cron:  recurring execution (Airflow schedule=<cron>).
+//
+// Only one active schedule per workflow is allowed regardless of type;
+// callers must Cancel the existing one before registering another. After
+// persisting the row the DAG metadata is rewritten so Airflow picks up the
+// new schedule on its next parse cycle.
+func (s *WorkflowScheduleService) Schedule(workflowID string, req model.CreateWorkflowScheduleReq) (*model.WorkflowSchedule, error) {
+	if workflowID == "" {
+		return nil, errors.New("please provide the workflow id")
+	}
+	s.syncOverdueOnceSchedule(workflowID)
+
+	hasRunAt := req.RunAt != nil && !req.RunAt.IsZero()
+	hasCron := req.Cron != nil && strings.TrimSpace(*req.Cron) != ""
+	switch {
+	case hasRunAt && hasCron:
+		return nil, errors.New("provide exactly one of run_at / cron, not both")
+	case !hasRunAt && !hasCron:
+		return nil, errors.New("provide one of run_at / cron")
+	}
+
+	workflow, err := mapper.GetWorkflowFromDB(workflowID)
+	if err != nil {
+		return nil, errors.New("workflow not found: " + err.Error())
+	}
+
+	existing, err := dao.WorkflowScheduleGetActive(workflowID)
+	if err != nil {
+		return nil, err
+	}
+	if existing != nil {
+		return nil, errors.New("workflow already has an active schedule; cancel it first (schedule_id=" + existing.ID + ")")
+	}
+
+	row := &model.WorkflowSchedule{
+		ID:         uuid.New().String(),
+		WorkflowID: workflowID,
+		Status:     model.WorkflowScheduleStatusActive,
+	}
+	if hasRunAt {
+		if !req.RunAt.After(time.Now()) {
+			return nil, errors.New("run_at must be in the future")
+		}
+		runAtUTC := req.RunAt.UTC()
+		row.Type = model.WorkflowScheduleTypeOnce
+		row.RunAt = &runAtUTC
+	} else {
+		cron := strings.TrimSpace(*req.Cron)
+		row.Type = model.WorkflowScheduleTypeCron
+		row.Cron = &cron
+	}
+
+	if err := dao.WorkflowScheduleCreate(row); err != nil {
+		return nil, err
+	}
+
+	if err := s.refreshDAG(workflow); err != nil {
+		// rollback the schedule row so DAG and DB stay consistent
+		_ = dao.WorkflowScheduleUpdateStatus(row.ID, model.WorkflowScheduleStatusCanceled)
+		return nil, err
+	}
+
+	return row, nil
+}
+
+// Cancel marks the workflow's active schedule as canceled and rewrites the
+// DAG metadata so the schedule line is dropped (DAG becomes manual-trigger
+// only again). Since at most one active schedule per workflow is allowed,
+// identifying the target by workflow id alone is unambiguous.
+func (s *WorkflowScheduleService) Cancel(workflowID string) (*model.WorkflowSchedule, error) {
+	if workflowID == "" {
+		return nil, errors.New("please provide the workflow id")
+	}
+	s.syncOverdueOnceSchedule(workflowID)
+
+	row, err := dao.WorkflowScheduleGetActive(workflowID)
+	if err != nil {
+		return nil, err
+	}
+	if row == nil {
+		return nil, errors.New("no active schedule for this workflow")
+	}
+
+	if err := dao.WorkflowScheduleUpdateStatus(row.ID, model.WorkflowScheduleStatusCanceled); err != nil {
+		return nil, err
+	}
+	row.Status = model.WorkflowScheduleStatusCanceled
+
+	workflow, err := mapper.GetWorkflowFromDB(workflowID)
+	if err == nil {
+		_ = s.refreshDAG(workflow)
+	}
+
+	return row, nil
+}
+
+// GetLatest returns the workflow's most recently created schedule row
+// regardless of status (active / executed / canceled), or (nil, nil) when
+// there's no schedule history. Callers branch on .status to interpret the
+// result.
+func (s *WorkflowScheduleService) GetLatest(workflowID string) (*model.WorkflowSchedule, error) {
+	if workflowID == "" {
+		return nil, errors.New("please provide the workflow id")
+	}
+	s.syncOverdueOnceSchedule(workflowID)
+	return dao.WorkflowScheduleGetLatest(workflowID)
+}
+
+// syncOverdueOnceSchedule promotes the workflow's active one-shot schedule
+// to "executed" when Airflow has already scheduler-triggered it. Matching is
+// strict: only DAGRuns with run_type="scheduled" and logical_date within ±1s
+// of schedule.run_at count — manual triggers and backfills are ignored so a
+// stray POST /run can't flip the schedule.
+//
+// Cron schedules are intentionally left alone: a cron row represents a
+// recurring rule, not a single execution, and stays active until canceled.
+//
+// Called lazily at every schedule API entry point (POST/GET/DELETE) so the
+// system has no background worker. Failures are silent — sync is best-effort
+// and never blocks the actual request.
+func (s *WorkflowScheduleService) syncOverdueOnceSchedule(workflowID string) {
+	row, err := dao.WorkflowScheduleGetActive(workflowID)
+	if err != nil || row == nil {
+		return
+	}
+	if row.Type != model.WorkflowScheduleTypeOnce || row.RunAt == nil {
+		return
+	}
+	if row.RunAt.After(time.Now()) {
+		return // not due yet
+	}
+
+	workflow, err := mapper.GetWorkflowFromDB(workflowID)
+	if err != nil {
+		return
+	}
+	client, err := airflow.GetClient()
+	if err != nil {
+		return
+	}
+	runs, err := client.GetDAGRuns(common.WorkflowDagID(workflow))
+	if err != nil || runs.DagRuns == nil {
+		return
+	}
+
+	target := row.RunAt.UTC()
+	const tolerance = time.Second
+	for _, run := range *runs.DagRuns {
+		if run.GetRunType() != "scheduled" {
+			continue
+		}
+		ld := run.GetLogicalDate()
+		if ld.IsZero() {
+			continue
+		}
+		diff := ld.UTC().Sub(target)
+		if diff < 0 {
+			diff = -diff
+		}
+		if diff <= tolerance {
+			_ = dao.WorkflowScheduleUpdateStatus(row.ID, model.WorkflowScheduleStatusExecuted)
+			return
+		}
+	}
+}
+
+// refreshDAG re-writes the DAG metadata so gusty.writeDAGMetadata picks up
+// the latest schedule state from DB.
+func (s *WorkflowScheduleService) refreshDAG(workflow *model.Workflow) error {
+	client, err := airflow.GetClient()
+	if err != nil {
+		return err
+	}
+	if err := client.CreateDAG(workflow); err != nil {
+		return errors.New("failed to refresh the DAG metadata (error: " + err.Error() + ")")
+	}
+	return nil
+}

--- a/pkg/api/rest/service/workflow_service.go
+++ b/pkg/api/rest/service/workflow_service.go
@@ -384,6 +384,118 @@ func (s *WorkflowService) GetWorkflowVersion(wfID, versionID string) (*model.Wor
 	return dao.WorkflowVersionGet(versionID, wfID)
 }
 
+// RollbackWorkflow restores the workflow's task graph + metadata from the
+// snapshot identified by versionNo (1-based, scoped to the workflow). The
+// rollback is recorded as a fresh WorkflowVersion entry with action="rollback"
+// and source_template_id=<source version id>, so the lineage stays
+// queryable.
+//
+// The diff against the current workflow is computed via
+// mapper.BuildWorkflowGraphDiff — same path UpdateWorkflow uses — so tasks
+// that exist by name in both current and target keep their IDs (and Airflow
+// task history continuity), tasks only in the target get fresh IDs, and
+// tasks only in the current get soft-deleted with a "rollback_drop" snapshot
+// for forensics. workflow_schedules rows are left untouched; schedule
+// lifecycle is orthogonal to workflow definition.
+//
+// Refuses to roll back to action="delete" snapshots (no meaningful state to
+// restore). Deleted workflows are not supported in this first cut — restore
+// them first via a future RestoreWorkflow path.
+func (s *WorkflowService) RollbackWorkflow(wfID string, versionNo int) (*model.Workflow, error) {
+	if wfID == "" {
+		return nil, errors.New("please provide the workflow id")
+	}
+	if versionNo <= 0 {
+		return nil, errors.New("version_no must be a positive integer")
+	}
+
+	workflow, err := dao.WorkflowGet(wfID)
+	if err != nil {
+		return nil, err
+	}
+	if workflow.IsDeleted {
+		return nil, errors.New("cannot rollback a deleted workflow")
+	}
+
+	version, err := dao.WorkflowVersionGetByNo(wfID, versionNo)
+	if err != nil {
+		return nil, err
+	}
+	if version == nil {
+		return nil, errors.New("workflow version not found")
+	}
+	if version.Action == "delete" {
+		return nil, errors.New("cannot rollback to a delete-action version")
+	}
+
+	target := version.RawData
+	specVersion := target.SpecVersion
+	if specVersion == "" {
+		specVersion = model.WorkflowSpecVersion_LATEST
+	}
+
+	createDataReq := mapper.DataToCreateDataReq(target.Data)
+	newData, err := mapper.CreateDataReqToData(specVersion, createDataReq)
+	if err != nil {
+		return nil, err
+	}
+
+	diff, err := mapper.BuildWorkflowGraphDiff(workflow, newData)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, tg := range diff.TaskGroupsToUpsert {
+		taskGroup := tg
+		if err := dao.TaskGroupSave(&taskGroup); err != nil {
+			return nil, err
+		}
+	}
+	for _, t := range diff.TasksToUpsert {
+		task := t
+		if err := dao.TaskSave(&task); err != nil {
+			return nil, err
+		}
+	}
+	if err := captureSoftDroppedTaskSnapshots(workflow, diff.TasksToSoftDrop, "rollback_drop"); err != nil {
+		return nil, err
+	}
+	for _, t := range diff.TasksToSoftDrop {
+		task := t
+		if err := dao.TaskDelete(&task); err != nil {
+			return nil, err
+		}
+	}
+	for _, tg := range diff.TaskGroupsToSoftDrop {
+		taskGroup := tg
+		if err := dao.TaskGroupDelete(&taskGroup); err != nil {
+			return nil, err
+		}
+	}
+
+	workflow.Name = target.Name
+	workflow.SpecVersion = specVersion
+	workflow.Data = diff.WorkflowData
+
+	if err := dao.WorkflowUpdate(workflow); err != nil {
+		return nil, err
+	}
+
+	if _, err = dao.WorkflowCreateSnapshot(workflow, "rollback", "rollback", version.ID); err != nil {
+		return nil, err
+	}
+
+	client, err := airflow.GetClient()
+	if err != nil {
+		return nil, err
+	}
+	if err := client.CreateDAG(workflow); err != nil {
+		return nil, errors.New("failed to refresh the workflow DAG (error: " + err.Error() + ")")
+	}
+
+	return workflow, nil
+}
+
 func workflowTaskByID(workflow *model.Workflow) map[string]model.Task {
 	tasks := make(map[string]model.Task)
 	if workflow == nil {


### PR DESCRIPTION
## Summary
  
  두 가지 워크플로우 관리 기능을 추가한다.
  
  - Workflow Schedule API — 1회성(once) 또는 반복(cron) 실행 예약. Airflow native scheduling 활용, cm-cicada 측 polling worker 없음.
  - Workflow Version Rollback API — 워크플로우를 과거 WorkflowVersion 스냅샷 시점으로 복원. UpdateWorkflow와 동일한 name 기반 diff 경로
  재사용으로 Airflow per-task 이력 연속성 보존.
  
  추가로 gusty의 default_args 마샬링 누락 버그 수정 포함.
  
  ## 1. Workflow Schedule API

  ### API

  | Method | Path | 설명 |
  |---|---|---|
  | POST | /workflow/{wfId}/schedule | 1회성(run_at) 또는 반복(cron) 예약 등록 |
  | GET  | /workflow/{wfId}/schedule | 최신 schedule 단일 객체 (status 무관) 또는 null |
  | DELETE | /workflow/{wfId}/schedule | active schedule을 canceled로 soft delete |
  
  ### Request body (POST)

  1회성:
  ```json
  {"run_at": "2026-05-15T09:00:00+09:00"}
```
  반복:
```json
  {"cron": "0 9 * * 1"}
```
  @daily, @hourly 같은 Airflow preset도 그대로 받음. run_at과 cron 중 정확히 하나만 제공.
  
  ---
  ### 2. Workflow Version Rollback API

  API

  POST /workflow/{wfId}/version/{versionNo}/rollback

  - body 없음 (clone 패턴과 동일)
  - versionNo는 양의 정수 (1-based, 워크플로우 내 sequential version_no)
  - 응답: 롤백 후 Workflow 객체

  사용 예:
  curl -X POST -u default:default http://<cm-cicada>/cicada/workflow/<wfId>/version/3/rollback