### PR TITLE
airflow: JWT 서명 키를 airflow.cfg 평문 대신 환경변수로 주입

### DIFF
--- a/_airflow/.env
+++ b/_airflow/.env
@@ -3,3 +3,6 @@ SMTP_USER=XXX@gmail.com
 SMTP_PASSWORD=XXX
 SMTP_PORT=587
 SMTP_MAIL_FROM=XXX@gmail.com
+# Airflow Task Execution API JWT 서명 키. 로컬 개발용 고정값이며(비밀 아님),
+# 실제 배포 시에는 각 환경에서 별도 값으로 교체한다.
+AIRFLOW_JWT_SECRET=cm-cicada-local-dev-jwt-secret

--- a/_airflow/airflow-home/airflow.cfg
+++ b/_airflow/airflow-home/airflow.cfg
@@ -42,7 +42,9 @@ fallback_page_limit = 100
 # 워커(task SDK)가 api-server의 /execution/... 를 호출할 때 쓰는 토큰을 이 키로 서명/검증한다.
 # 기본값은 프로세스마다 랜덤 생성되므로, 지정하지 않으면 서명한 쪽과 검증하는 쪽의 키가
 # 달라져서 모든 태스크가 "Invalid auth token"(403)으로 죽는다. 반드시 고정해야 한다.
-jwt_secret = HkQ2mCcqXKM8xVnRZ4pLuT7ByWdEfGaJ
+# 평문 시크릿을 저장소에 커밋하지 않기 위해 값은 여기 두지 않고 환경변수
+# AIRFLOW__API_AUTH__JWT_SECRET 로 주입한다(docker-compose.yml + .env 참고).
+jwt_secret =
 
 [fab]
 # Airflow 3에서 [webserver]에 있던 FAB 관련 옵션들이 이 섹션으로 이동했다.

--- a/_airflow/docker-compose.yml
+++ b/_airflow/docker-compose.yml
@@ -38,6 +38,9 @@ services:
             # monitor_dag가 Airflow REST API(/api/v2)를 호출할 때 쓰는 커넥션.
             # Airflow 3에서는 태스크가 메타DB에 직접 접근할 수 없어서 API를 거쳐야 한다.
             - AIRFLOW_CONN_AIRFLOW_API={"conn_type":"http","host":"localhost","port":8080,"schema":"http","login":"airflow","password":"airflow_pass"}
+            # Task Execution API용 JWT 서명 키. 평문을 airflow.cfg에 커밋하지 않기 위해
+            # 환경변수로 주입한다(.env 참고). 배포처(cm-mayfly 등)에서 자체 값으로 덮어쓴다.
+            - AIRFLOW__API_AUTH__JWT_SECRET=${AIRFLOW_JWT_SECRET}
         command: >
             /bin/bash -c "
                 # Wait for MySQL


### PR DESCRIPTION
## 요약

`_airflow/airflow-home/airflow.cfg`에 평문으로 커밋돼 있던 Task Execution API용 `jwt_secret`을 제거하고, 환경변수 `AIRFLOW__API_AUTH__JWT_SECRET`로 주입하도록 변경한다. (#74)

이 값은 워커(task SDK)가 api-server의 `/execution/...`를 호출할 때 쓰는 토큰의 서명/검증 키다. 값의 **역할·일관성**은 그대로이고, Airflow가 그 키를 **어디서 읽어오는지**(cfg → env)만 바뀐다.

## 변경 사항

- `airflow-home/airflow.cfg` — `jwt_secret` 값 제거(빈 값). 환경변수로 주입한다는 주석 추가.
- `docker-compose.yml` — `airflow-server`에 `AIRFLOW__API_AUTH__JWT_SECRET=${AIRFLOW_JWT_SECRET}` 추가. 컨테이너 내 모든 airflow 프로세스가 같은 env를 읽으므로 서명/검증 키가 일치한다.
- `.env` — 로컬 개발용 고정값 `AIRFLOW_JWT_SECRET`(저엔트로피, 비밀 아님) 추가. 실제 배포 시 각 환경에서 교체.

## 배경

cm-cicada를 사용하는 cm-mayfly의 시크릿 스캐너(gitleaks)가 이 평문 값을 generic-api-key로 탐지해 레포 업데이트를 막고 있었다. 고엔트로피 값을 저장소에서 제거해 스캐너 오탐을 없애고, Airflow 문서 권장대로 환경변수 주입 방식으로 전환한다.

값을 고정하지 않으면 프로세스마다 랜덤 생성되어 서명/검증 키가 달라지고 모든 태스크가 "Invalid auth token"(403)으로 죽으므로, 반드시 고정값이 유지된다.

Closes #74
