### PR TITLE
fix(example): Use source_workflow_run_id in trigger_email templates

### DIFF
--- a/lib/airflow/example/workflow_template/migrate_infra_workflow.json
+++ b/lib/airflow/example/workflow_template/migrate_infra_workflow.json
@@ -56,8 +56,8 @@
             "task_component": "trigger_email",
             "spec": {
               "conf": {
-                "source_workflow_id": "{{ dag_run.conf['workflow_id'] if dag_run.conf else dag.dag_id }}",
-                "source_workflow_key": "{{ dag_run.conf['workflow_key'] if dag_run.conf else dag.dag_id }}",
+                "source_workflow_id": "{{ dag.dag_id }}",
+                "source_workflow_run_id": "{{ dag_run.run_id }}",
                 "to_email": "test@test.com"
               }
             },

--- a/lib/airflow/example/workflow_template/migrate_software_workflow.json
+++ b/lib/airflow/example/workflow_template/migrate_software_workflow.json
@@ -35,7 +35,13 @@
           {
             "name": "send_result_via_email",
             "task_component": "trigger_email",
-            "spec": {},
+            "spec": {
+              "conf": {
+                "source_workflow_id": "{{ dag.dag_id }}",
+                "source_workflow_run_id": "{{ dag_run.run_id }}",
+                "to_email": "test@test.com"
+              }
+            },
             "dependencies": [
               "run_software_migration"
             ]


### PR DESCRIPTION
V2 templates still passed the V1 source_workflow_key, so monitor_dag raised ValueError (shallow merge drops the component default). Switch to {{ dag.dag_id }} / {{ dag_run.run_id }} and fill in the empty software spec.