### PR TITLE
airflow: Empty api base_url so UI auth redirects are relative

### DIFF
--- a/_airflow/airflow-home/airflow.cfg
+++ b/_airflow/airflow-home/airflow.cfg
@@ -29,7 +29,10 @@ sql_alchemy_conn = mysql+mysqldb://airflow:airflow_pass@airflow-mysql/airflow
 # Airflow 3에서 [webserver] 섹션이 없어지고 api-server 설정이 여기로 왔다.
 host = 0.0.0.0
 port = 8080
-base_url = http://localhost:8080
+# base_url을 비워두면 Airflow가 로그인/로그아웃 리다이렉트를 상대경로(/auth/login/)로
+# 내보낸다. 브라우저가 접속한 주소 기준으로 해석하므로, 공인 IP·호스트명 등 어떤 주소로
+# 들어와도 그 주소를 유지한다(고정 localhost:8080으로 튕기지 않음).
+base_url =
 secret_key = i1SEBjQvnCA93YEo+yjYEA==
 expose_config = False
 


### PR DESCRIPTION
## 무엇
Airflow의 `[api] base_url` 을 빈 값으로 둔다 (`_airflow/airflow-home/airflow.cfg`).

## 왜
기존엔 `base_url = http://localhost:8080` 으로 고정돼 있어, 공인 IP·호스트명으로 Airflow UI 에 접속해도 로그인/로그아웃 시 `localhost:8080` 으로 리다이렉트되어 접속이 끊겼다. base_url 을 비우면 Airflow 가 auth 리다이렉트를 상대경로(`/auth/login/`)로 내보내고, 브라우저가 접속한 주소 기준으로 해석한다 → 어떤 주소로 들어와도 그 주소를 유지한다.

## 영향
- **당장 진행 중인 테스트/워크플로우 실행에는 영향이 없다.** 마이그레이션 실행·태스크 컴포넌트·내부 API 호출(`AIRFLOW_CONN_AIRFLOW_API=localhost`)과 무관하며, 서버측 라우팅/상대경로 자원은 그대로다.
- **Airflow UI 접근을 위해 필요한 부가 설정**이다. (외부 주소로 UI 로그인이 가능해진다.)

> 참고: cm-mayfly 배포(compose env + vendored airflow.cfg)에도 동일하게 반영한다.
